### PR TITLE
default-stackdriver-user

### DIFF
--- a/clients/go/coreutils/logs/stackdriver.go
+++ b/clients/go/coreutils/logs/stackdriver.go
@@ -20,7 +20,7 @@ type stackdriverLogPlugin struct {
 func (s *stackdriverLogPlugin) GetTaskLog(podName, namespace, containerName, containerID, logName string) (core.TaskLog, error) {
 	return core.TaskLog{
 		Uri: fmt.Sprintf(
-			"https://console.cloud.google.com/logs/viewer?project=%s&angularJsUrl=%%2Flogs%%2Fviewer%%3Fproject%%3D%s&authuser=1&resource=%s&advancedFilter=logName:%s",
+			"https://console.cloud.google.com/logs/viewer?project=%s&angularJsUrl=%%2Flogs%%2Fviewer%%3Fproject%%3D%s&resource=%s&advancedFilter=logName:%s",
 			s.gcpProject,
 			s.gcpProject,
 			s.logResource,

--- a/clients/go/coreutils/logs/stackdriver_test.go
+++ b/clients/go/coreutils/logs/stackdriver_test.go
@@ -30,13 +30,13 @@ func Test_stackdriverLogPlugin_GetTaskLog(t *testing.T) {
 			"podName-proj1",
 			fields{gcpProject: "test-gcp-project", logResource: "aws_ec2_instance"},
 			args{podName: "podName"},
-			core.TaskLog{Uri: "https://console.cloud.google.com/logs/viewer?project=test-gcp-project&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3Dtest-gcp-project&authuser=1&resource=aws_ec2_instance&advancedFilter=logName:podName", MessageFormat: core.TaskLog_JSON}, false,
+			core.TaskLog{Uri: "https://console.cloud.google.com/logs/viewer?project=test-gcp-project&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3Dtest-gcp-project&resource=aws_ec2_instance&advancedFilter=logName:podName", MessageFormat: core.TaskLog_JSON}, false,
 		},
 		{
 			"podName2-proj2",
 			fields{gcpProject: "proj2", logResource: "res1"},
 			args{podName: "long-pod-name-xyyyx"},
-			core.TaskLog{Uri: "https://console.cloud.google.com/logs/viewer?project=proj2&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3Dproj2&authuser=1&resource=res1&advancedFilter=logName:long-pod-name-xyyyx", MessageFormat: core.TaskLog_JSON}, false,
+			core.TaskLog{Uri: "https://console.cloud.google.com/logs/viewer?project=proj2&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3Dproj2&resource=res1&advancedFilter=logName:long-pod-name-xyyyx", MessageFormat: core.TaskLog_JSON}, false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
We had `&authuser=1` argument in the stackdriver links that was opening with second logged-in user. While some users logged in to a personal gmail first, many other in the organization are logged in with their lyft accounts first.
It is better to not specify this argument and expect all L5 Flyte users are logged in to gmail with @lyft.com account first. If that isn't the case we will instruct them to sign out from all google accounts and sign in again with @lyft.com first.
