### PR TITLE
Fix Make nil Literal

### DIFF
--- a/clients/go/coreutils/literals.go
+++ b/clients/go/coreutils/literals.go
@@ -148,7 +148,7 @@ func MakeLiteral(v interface{}) (*core.Literal, error) {
 			Value: &core.Literal_Scalar{
 				Scalar: &core.Scalar{
 					Value: &core.Scalar_NoneType{
-						NoneType: nil,
+						NoneType: &core.Void{},
 					},
 				},
 			},


### PR DESCRIPTION
Make nil literal creation (this code is used for tests) consistent between this code and the production code that creates nil literals for failed subtasks (in array-plugins)