### PR TITLE
GitHub workflow for publishing to Pypi

### DIFF
--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,3 @@ jobs:
       name: unit tests
       install: make install
       script: make test_unit
-    - if: tag IS present AND fork = false
-      stage: release
-      name: release Python package
-      install: skip
-      script: make release


### PR DESCRIPTION
# TL;DR
This removes the travis job and uses GitHub workflows/actions instead to publish to pypi.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
See https://github.com/actions/starter-workflows/blob/master/ci/python-publish.yml for primary example.

## Tracking Issue
none.

## Follow-up issue
Eventually we'll want to move the unit testing over to GitHub as well, just to centralize where we do CI/CD.
