### PR TITLE
Fix Stackdriver log link

### DIFF
--- a/clients/go/coreutils/logs/stackdriver.go
+++ b/clients/go/coreutils/logs/stackdriver.go
@@ -20,7 +20,7 @@ type stackdriverLogPlugin struct {
 func (s *stackdriverLogPlugin) GetTaskLog(podName, namespace, containerName, containerID, logName string) (core.TaskLog, error) {
 	return core.TaskLog{
 		Uri: fmt.Sprintf(
-			"https://console.cloud.google.com/logs/viewer?project=%s&angularJsUrl=%%2Flogs%%2Fviewer%%3Fproject%%3D%s&resource=%s&advancedFilter=resource.labels.pod_name%3D%s",
+			"https://console.cloud.google.com/logs/viewer?project=%s&angularJsUrl=%%2Flogs%%2Fviewer%%3Fproject%%3D%s&resource=%s&advancedFilter=resource.labels.pod_name%%3D%s",
 			s.gcpProject,
 			s.gcpProject,
 			s.logResource,

--- a/clients/go/coreutils/logs/stackdriver.go
+++ b/clients/go/coreutils/logs/stackdriver.go
@@ -6,10 +6,10 @@ import (
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
 )
 
-// TL;DR Log links in Stackdriver for configured GCP project and log Resource - Assumption: logName = podName
+// TL;DR Log links in Stackdriver for configured GCP project and log Resource
 //
 // This is a simple stackdriver log plugin that creates a preformatted log link for a given project and logResource
-// assuming that the logName is the name of the pod in kubernetes
+// using resource.labels.pod_name as advancedFilter
 type stackdriverLogPlugin struct {
 	// the name of the project in GCP that the logs are being published under
 	gcpProject string
@@ -20,7 +20,7 @@ type stackdriverLogPlugin struct {
 func (s *stackdriverLogPlugin) GetTaskLog(podName, namespace, containerName, containerID, logName string) (core.TaskLog, error) {
 	return core.TaskLog{
 		Uri: fmt.Sprintf(
-			"https://console.cloud.google.com/logs/viewer?project=%s&angularJsUrl=%%2Flogs%%2Fviewer%%3Fproject%%3D%s&resource=%s&advancedFilter=logName:%s",
+			"https://console.cloud.google.com/logs/viewer?project=%s&angularJsUrl=%%2Flogs%%2Fviewer%%3Fproject%%3D%s&resource=%s&advancedFilter=resource.labels.pod_name%3D%s",
 			s.gcpProject,
 			s.gcpProject,
 			s.logResource,

--- a/clients/go/coreutils/logs/stackdriver_test.go
+++ b/clients/go/coreutils/logs/stackdriver_test.go
@@ -30,13 +30,13 @@ func Test_stackdriverLogPlugin_GetTaskLog(t *testing.T) {
 			"podName-proj1",
 			fields{gcpProject: "test-gcp-project", logResource: "aws_ec2_instance"},
 			args{podName: "podName"},
-			core.TaskLog{Uri: "https://console.cloud.google.com/logs/viewer?project=test-gcp-project&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3Dtest-gcp-project&resource=aws_ec2_instance&advancedFilter=logName:podName", MessageFormat: core.TaskLog_JSON}, false,
+			core.TaskLog{Uri: "https://console.cloud.google.com/logs/viewer?project=test-gcp-project&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3Dtest-gcp-project&resource=aws_ec2_instance&advancedFilter=resource.labels.pod_name%3DpodName", MessageFormat: core.TaskLog_JSON}, false,
 		},
 		{
 			"podName2-proj2",
 			fields{gcpProject: "proj2", logResource: "res1"},
 			args{podName: "long-pod-name-xyyyx"},
-			core.TaskLog{Uri: "https://console.cloud.google.com/logs/viewer?project=proj2&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3Dproj2&resource=res1&advancedFilter=logName:long-pod-name-xyyyx", MessageFormat: core.TaskLog_JSON}, false,
+			core.TaskLog{Uri: "https://console.cloud.google.com/logs/viewer?project=proj2&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3Dproj2&resource=res1&advancedFilter=resource.labels.pod_name%3Dlong-pod-name-xyyyx", MessageFormat: core.TaskLog_JSON}, false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# TL;DR
This PR fixes Stackdriver log link using `resource.labels.pod_name` as `advancedFilter` instead of `logName`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
I copied the generated link, modified it accordingly and verified it worked.

## Tracking Issue
https://github.com/lyft/flyte/issues/480

## Follow-up issue
_NA_
