### PR TITLE
Deprecate Log Plugins

### DIFF
--- a/clients/go/coreutils/logs/cloudwatch.go
+++ b/clients/go/coreutils/logs/cloudwatch.go
@@ -36,6 +36,7 @@ func (s cloudwatchLogPlugin) GetTaskLog(podName, namespace, containerName, conta
 	}, nil
 }
 
+// Deprecated: Please use NewTemplateLogPlugin from github.com/lyft/flyteplugins/go/tasks/pluginmachinery/tasklog instead.
 func NewCloudwatchLogPlugin(region, groupName string) LogPlugin {
 	return &cloudwatchLogPlugin{
 		region:    region,

--- a/clients/go/coreutils/logs/kubernetes.go
+++ b/clients/go/coreutils/logs/kubernetes.go
@@ -18,6 +18,7 @@ func (s kubernetesLogPlugin) GetTaskLog(podName, namespace, containerName, conta
 	}, nil
 }
 
+// Deprecated: Please use NewTemplateLogPlugin from github.com/lyft/flyteplugins/go/tasks/pluginmachinery/tasklog instead.
 func NewKubernetesLogPlugin(k8sURL string) LogPlugin {
 	return &kubernetesLogPlugin{
 		k8sURL: k8sURL,

--- a/clients/go/coreutils/logs/logs.go
+++ b/clients/go/coreutils/logs/logs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
 )
 
+// Deprecated: Please use Plugin interface from github.com/lyft/flyteplugins/go/tasks/pluginmachinery/tasklog instead.
 type LogPlugin interface {
 	// Generates a TaskLog object given necessary computation information
 	GetTaskLog(podName, namespace, containerName, containerID, logName string) (core.TaskLog, error)

--- a/clients/go/coreutils/logs/stackdriver.go
+++ b/clients/go/coreutils/logs/stackdriver.go
@@ -31,6 +31,7 @@ func (s *stackdriverLogPlugin) GetTaskLog(podName, namespace, containerName, con
 	}, nil
 }
 
+// Deprecated: Please use NewTemplateLogPlugin from github.com/lyft/flyteplugins/go/tasks/pluginmachinery/tasklog instead.
 func NewStackdriverLogPlugin(gcpProject, logResource string) LogPlugin {
 	return &stackdriverLogPlugin{
 		gcpProject:  gcpProject,


### PR DESCRIPTION
# TL;DR
Mark log plugins as deprecated in favor of the new interface in plugin machinery.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/549
https://github.com/lyft/flyte/issues/448